### PR TITLE
Make call to `indexOf()` more efficient

### DIFF
--- a/src/main/java/org/plumelib/reflection/Signatures.java
+++ b/src/main/java/org/plumelib/reflection/Signatures.java
@@ -99,7 +99,7 @@ public final class Signatures {
       throw new IllegalArgumentException("Bad class file name: " + classfilename);
     }
     @SuppressWarnings("index:assignment") // "/" is not the last character
-    @IndexFor("classfilename") int start = classfilename.lastIndexOf("/") + 1;
+    @IndexFor("classfilename") int start = classfilename.lastIndexOf('/') + 1;
     int end = classfilename.length() - 6;
     return classfilename.substring(start, end);
   }
@@ -783,7 +783,7 @@ public final class Signatures {
   public static @Nullable @FieldDescriptor String methodDescriptorToReturnType(
       @MethodDescriptor String methodDescriptor) {
     @SuppressWarnings("signature:assignment") // string manipulation
-    @FieldDescriptor String result = methodDescriptor.substring(methodDescriptor.indexOf(")") + 1);
+    @FieldDescriptor String result = methodDescriptor.substring(methodDescriptor.indexOf(')') + 1);
     return result.equals("V") ? null : result;
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal index lookups to use character-based operations.
  * No changes to behavior, public APIs, configuration, or outputs; existing functionality is unchanged.
  * No user-facing impact; performance and compatibility remain the same.
  * No migration or action required.
  * Testing and documentation unaffected.
  * Release behavior identical to previous version.
  * Platforms and environments supported remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->